### PR TITLE
correct regex for special characters

### DIFF
--- a/script.js
+++ b/script.js
@@ -7,7 +7,7 @@ const requirements = [
     {regex: /.{8,}/, index: 0}, // minimum of 8 characters
     {regex: /[0-9]/, index: 1}, // At least one number
     {regex: /[a-z]/, index: 2}, // At least one lowercase letter
-    {regex: /[^A-Za-z0-9]/, index: 3}, // At least one spacial character
+    {regex: /[!@#$%^&*]/, index: 3}, // At least one special character
     {regex: /[A-Z]/, index: 4}, // At least one uppercase letter
 ]
 


### PR DESCRIPTION
previous special characters did not pass test for space or other symbols that are not special characters.